### PR TITLE
Equals refactor

### DIFF
--- a/BreakpointSamples/Automation of Data Entry or Data Selection Processes/AddImagesToProductsInBulk.vb
+++ b/BreakpointSamples/Automation of Data Entry or Data Selection Processes/AddImagesToProductsInBulk.vb
@@ -20,7 +20,7 @@ Public Module ExternalApplicationCustomRibbonButtonClick
 		Try
 			Dim dir As New DirectoryInfo(directoryName)
 			For Each f As FileInfo In dir.GetFiles()
-				If f.Extension = ".jpg" OrElse f.Extension = ".png" Then
+				If f.Extension.Equals(".jpg") = True OrElse f.Extension.Equals(".png") = True Then
 					Try
 						'There is an assumption that the image names match codes within Vision
 						product = Sybiz.Vision.Platform.Inventory.Product.GetObject(f.Name.Replace(f.Extension,""))							

--- a/BreakpointSamples/Automation of Data Entry or Data Selection Processes/EnterCurrentQuantityIntoCustomFieldOnProductChanging.vb
+++ b/BreakpointSamples/Automation of Data Entry or Data Selection Processes/EnterCurrentQuantityIntoCustomFieldOnProductChanging.vb
@@ -9,7 +9,7 @@
 		Dim customField As Object = e.Line.ExtendedProperties.Item("QOH")
 
 		'If field being edited is either account or location then...				
-		If e.FieldName = "Account" OrElse e.FieldName = "Location" Then
+		If e.FieldName.Equals("Account") = True OrElse e.FieldName.Equals("Location") = True Then
 			'Get the quantity
 			Dim qty As Decimal = Sybiz.Vision.Platform.Core.Data.ScalarCommand.Execute(Of Decimal)(String.Format("SELECT Quantity FROM [ic].[ProductBalanceExpanded] WHERE ProductId = {0} AND LocationId = {1}", e.Line.Account, e.Line.Location))
 			'Insert the quantuty into the custom field

--- a/BreakpointSamples/Automation of Data Entry or Data Selection Processes/ImportInvoiceViaDataTable.vb
+++ b/BreakpointSamples/Automation of Data Entry or Data Selection Processes/ImportInvoiceViaDataTable.vb
@@ -9,9 +9,9 @@ Public Class ImportInvoiceViaDataTable
 	
   Public Sub Invoke(ByVal transaction As Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoice, ByVal e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCustomRibbonButtonClickEventArgs) 'Do not remove - SYBIZ
 
-    If e.Key = "Import" Then
+    If e.Key.Equals("Import") = True Then
       Dim fileName as String
-        Using frm as OpenFileDialog = BreakpointHelpers.ShowOpenFileDialog("",false,"*.csv")
+        Using frm as OpenFileDialog = BreakpointHelpers.ShowOpenFileDialog("", false, "*.csv")
           If frm.ShowDialog(e.Form) = DialogResult.OK Then
             fileName = frm.FileName
           End if

--- a/BreakpointSamples/Automation of Data Entry or Data Selection Processes/ImportServiceRequestViaExcelSpreadsheet.vb
+++ b/BreakpointSamples/Automation of Data Entry or Data Selection Processes/ImportServiceRequestViaExcelSpreadsheet.vb
@@ -9,7 +9,7 @@ Public Class ImportServiceRequestViaExcelSpreadsheet
 	
 	
 	Public Sub Invoke(ByVal e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCustomRibbonButtonClickEventArgs) 'Do not remove - SYBIZ
-        If e.Key = "ServiceRequestImport" Then
+        If e.Key.Equals("ServiceRequestImport") = True Then
             Try
                 Dim fileName as String
                 Using frm as OpenFileDialog = BreakpointHelpers.ShowOpenFileDialog("",false,"*.xslx")

--- a/BreakpointSamples/Automation of Data Entry or Data Selection Processes/RemoveFirstCharacterInProductCodeThroughCustomButton.vb
+++ b/BreakpointSamples/Automation of Data Entry or Data Selection Processes/RemoveFirstCharacterInProductCodeThroughCustomButton.vb
@@ -5,7 +5,7 @@ Public Module ExternalApplicationCustomRibbonButtonClick
 	'Breakpoint: ExternalApplicationCustomRibbonButtonClick
 
 	Public Sub Invoke(ByVal e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCustomRibbonButtonClickEventArgs)
-		If (e.Key = "REPLACEPRODUCTCODES") Then
+		If e.Key.Equals("REPLACEPRODUCTCODES") = True Then
 			System.Windows.Forms.Application.UseWaitCursor = true
 			Try						
 				Dim productsList as Sybiz.Vision.Platform.Inventory.ProductLookupInfoList = Sybiz.Vision.Platform.Inventory.ProductLookupInfoList.GetList()

--- a/BreakpointSamples/Automation of Data Entry or Data Selection Processes/UpdateAllDepreciationLineProjects.vb
+++ b/BreakpointSamples/Automation of Data Entry or Data Selection Processes/UpdateAllDepreciationLineProjects.vb
@@ -27,7 +27,7 @@
 		Dim project As Integer
 
 		'When clicking the button
-		If e.Key = "ProjectPropagation" AndAlso transaction.Lines.Count > 0 Then
+		If e.Key.Equals("ProjectPropagation") AndAlso transaction.Lines.Count > 0 Then
 
 			'Go through each line...
 			For Each line As Sybiz.Vision.Platform.FixedAssets.Transaction.DepreciationRunLine In transaction.Lines

--- a/BreakpointSamples/Automation of Data Entry or Data Selection Processes/UpdateAllDepreciationLineProjects.vb
+++ b/BreakpointSamples/Automation of Data Entry or Data Selection Processes/UpdateAllDepreciationLineProjects.vb
@@ -27,7 +27,7 @@
 		Dim project As Integer
 
 		'When clicking the button
-		If e.Key.Equals("ProjectPropagation") AndAlso transaction.Lines.Count > 0 Then
+		If e.Key.Equals("ProjectPropagation") = True AndAlso transaction.Lines.Count > 0 Then
 
 			'Go through each line...
 			For Each line As Sybiz.Vision.Platform.FixedAssets.Transaction.DepreciationRunLine In transaction.Lines

--- a/BreakpointSamples/Data Entry or Form Design/DownloadAllProductPictures.vb
+++ b/BreakpointSamples/Data Entry or Form Design/DownloadAllProductPictures.vb
@@ -6,7 +6,7 @@ Public Module ExternalApplicationCustomRibbonButtonClick
 
   Public Sub Invoke(ByVal e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCustomRibbonButtonClickEventArgs)				
 
-    If (e.Key = "PicDownload") Then
+    If e.Key.Equals("PicDownload") = True Then
       Dim errorlog As List(Of String) = New List(Of String)
       Dim dirname As String = BreakpointHelpers.GetStringValue(e.Form,"Directory Name","Please enter the directory name you wish to save product images to","C:\")
       Dim cont As DialogResult = BreakpointHelpers.ShowYesNoMessageBox(e.Form,"WARNING","Pressing yes will take all pictures attached to products and download them to " + dirname + " do you want to continue?")

--- a/BreakpointSamples/Implementing Custom Business Rules and Logic/DisableActiveFieldWhenJobHasWIP.vb
+++ b/BreakpointSamples/Implementing Custom Business Rules and Logic/DisableActiveFieldWhenJobHasWIP.vb
@@ -6,7 +6,7 @@ Public Class DisableActiveFieldWhenJobHasWIP
 	
   Public Sub Invoke(ByVal sender As System.Object, ByVal e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointPropertyDisabledEventArgs) 'Do not remove - SYBIZ
 
-    If e.PropertyName = "IsActive"
+    If e.PropertyName.Equals("IsActive") = True Then
       Dim job As Sybiz.Vision.Platform.JobCosting.Job = DirectCast(sender, Sybiz.Vision.Platform.JobCosting.Job)
       If job.IsNew = false AndAlso job.IsActive Then                             
         Dim jobDetail As Sybiz.Vision.Platform.JobCosting.JobDetailInfo = Sybiz.Vision.Platform.JobCosting.JobDetailInfo.GetObject(job.id)

--- a/BreakpointSamples/Implementing Custom Business Rules and Logic/RemoveIdenticalLinesOnTransaction.vb
+++ b/BreakpointSamples/Implementing Custom Business Rules and Logic/RemoveIdenticalLinesOnTransaction.vb
@@ -6,13 +6,13 @@
 
     Public Sub Invoke(transaction As Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoice, e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCellValueChangedEventArgs(Of Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoiceLine))
         'Check for the item field
-        If e.FieldName = "Account" Then
+        If e.FieldName.Equals("Account") Then
             'Iterate through each sales invoice line in the sales invoice
             For Each line As Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoiceLine In transaction.Lines
                 'Check the line being added against the currently iterated sales invoice line
                 If e.Line.Id <> line.Id AndAlso e.Line.AccountType = line.AccountType AndAlso e.Line.Account = line.Account Then
                     'Remove the line being added if the type and item is identical
-                    MessageBox.Show("Existing line with this item and account", "Breakpoints")
+                    BreakpointHelpers.ShowInformationMessage(e.Form, "Breakpoints", "Existing line with this item and account")
                     transaction.Lines.Remove(e.Line)
                     Exit For
                 End If

--- a/BreakpointSamples/Implementing Custom Business Rules and Logic/RemoveIdenticalLinesOnTransaction.vb
+++ b/BreakpointSamples/Implementing Custom Business Rules and Logic/RemoveIdenticalLinesOnTransaction.vb
@@ -6,7 +6,7 @@
 
     Public Sub Invoke(transaction As Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoice, e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCellValueChangedEventArgs(Of Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoiceLine))
         'Check for the item field
-        If e.FieldName.Equals("Account") Then
+        If e.FieldName.Equals("Account") = True Then
             'Iterate through each sales invoice line in the sales invoice
             For Each line As Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoiceLine In transaction.Lines
                 'Check the line being added against the currently iterated sales invoice line

--- a/BreakpointSamples/Implementing Custom Business Rules and Logic/RestrictPriceChangesExceptGLandFreight.vb
+++ b/BreakpointSamples/Implementing Custom Business Rules and Logic/RestrictPriceChangesExceptGLandFreight.vb
@@ -11,7 +11,7 @@
     ElseIf Sybiz.Vision.Platform.Security.Principal.CurrentPrincipal.IsInRole("FrontOfHouse") Then'OrElse...any other roles you want to restrict
     'Alternative method, do reverse where everyone BUT those in an 'admin' role are restricted.
     'ElseIf Sybiz.Vision.Platform.Security.Principal.CurrentPrincipal.IsInRole("PriceOverride") = False Then
-        If e.FieldName = "Charge" OrElse e.FieldName = "UnitChargeExclusive" OrElse e.FieldName = "ChargeExclusive" OrElse e.FieldName = "Discount" OrElse e.FieldName = "DiscountPercentage" OrElse e.FieldName = "UnitChargeInclusive" OrElse e.FieldName = "ChargeInclusive" Then
+        If e.FieldName.Equals("Charge") = True OrElse e.FieldName.Equals("UnitChargeExclusive") = True OrElse e.FieldName.Equals("ChargeExclusive") = True OrElse e.FieldName.Equals("Discount") = True OrElse e.FieldName.Equals("DiscountPercentage") = True OrElse e.FieldName.Equals("UnitChargeInclusive") = True OrElse e.FieldName.Equals("ChargeInclusive") = True Then
           e.Handled = True
         End If
     End If

--- a/BreakpointSamples/Implementing Custom Business Rules and Logic/SelectHighestPriceScaleWhenNoneExists.vb
+++ b/BreakpointSamples/Implementing Custom Business Rules and Logic/SelectHighestPriceScaleWhenNoneExists.vb
@@ -9,7 +9,7 @@ Public Class SelectHighestPriceScaleWhenNoneExists
   'Breakpoint: SalesInvoiceCellValueChanged
 
   Public Sub Invoke(ByVal transaction As Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoice, ByVal e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointSalesDeliveryInvoiceCellValueChangedEventArgs(Of Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoiceLine)) 'Do not remove - SYBIZ
-    If e.FieldName = "Account" OrElse e.FieldName = "UnitOfMeasure" Then
+    If e.FieldName.Equals("Account") OrElse e.FieldName.Equals("UnitOfMeasure") Then
       Dim p As Sybiz.Vision.Platform.Inventory.Transaction.IProductDetail = TryCast(e.Line, Sybiz.Vision.Platform.Inventory.Transaction.IProductDetail)
       
       If p IsNot Nothing AndAlso p.ProductDetails.IsValid Then 

--- a/BreakpointSamples/Implementing Custom Business Rules and Logic/SelectHighestPriceScaleWhenNoneExists.vb
+++ b/BreakpointSamples/Implementing Custom Business Rules and Logic/SelectHighestPriceScaleWhenNoneExists.vb
@@ -9,7 +9,7 @@ Public Class SelectHighestPriceScaleWhenNoneExists
   'Breakpoint: SalesInvoiceCellValueChanged
 
   Public Sub Invoke(ByVal transaction As Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoice, ByVal e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointSalesDeliveryInvoiceCellValueChangedEventArgs(Of Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoiceLine)) 'Do not remove - SYBIZ
-    If e.FieldName.Equals("Account") OrElse e.FieldName.Equals("UnitOfMeasure") Then
+    If e.FieldName.Equals("Account") = True OrElse e.FieldName.Equals("UnitOfMeasure") = True Then
       Dim p As Sybiz.Vision.Platform.Inventory.Transaction.IProductDetail = TryCast(e.Line, Sybiz.Vision.Platform.Inventory.Transaction.IProductDetail)
       
       If p IsNot Nothing AndAlso p.ProductDetails.IsValid Then 

--- a/BreakpointSamples/Modifying the Standard Workflow of Vision/CreateSupplierProductAndPurchaseTransaction.vb
+++ b/BreakpointSamples/Modifying the Standard Workflow of Vision/CreateSupplierProductAndPurchaseTransaction.vb
@@ -6,7 +6,7 @@
 
     Public Sub Invoke(e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCustomRibbonButtonClickEventArgs)
 
-        If e.Key.Equals("BreakpointKey") Then
+        If e.Key.Equals("BreakpointKey") = True Then
             'Show a new supplier form
             Dim formSupplier As Sybiz.Vision.Module.Coordinator.VisionDialogResult = Sybiz.Vision.Module.Coordinator.VisionApplication.GetApplication().CR.ShowSupplierForm(e.Form, 0, Nothing, Nothing)
 

--- a/BreakpointSamples/Modifying the Standard Workflow of Vision/CreateSupplierProductAndPurchaseTransaction.vb
+++ b/BreakpointSamples/Modifying the Standard Workflow of Vision/CreateSupplierProductAndPurchaseTransaction.vb
@@ -6,7 +6,7 @@
 
     Public Sub Invoke(e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCustomRibbonButtonClickEventArgs)
 
-        If e.Key = "BreakpointKey" Then
+        If e.Key.Equals("BreakpointKey") Then
             'Show a new supplier form
             Dim formSupplier As Sybiz.Vision.Module.Coordinator.VisionDialogResult = Sybiz.Vision.Module.Coordinator.VisionApplication.GetApplication().CR.ShowSupplierForm(e.Form, 0, Nothing, Nothing)
 

--- a/BreakpointSamples/Modifying the Standard Workflow of Vision/CreateWastageTransferLinesAutomatically.vb
+++ b/BreakpointSamples/Modifying the Standard Workflow of Vision/CreateWastageTransferLinesAutomatically.vb
@@ -12,7 +12,7 @@ Public Class CreateWastageTransferLines
 		Dim productDictionary as New Dictionary(Of String, Decimal)
 		
 		transaction.Lines.ToList().ForEach(Sub(ln) 
-							If ln.Notes.Equals("Automatically calculated wastage") Then
+							If ln.Notes.Equals("Automatically calculated wastage") = True Then
 								transaction.Lines.Remove(ln)
 							End If
 						End Sub)													

--- a/BreakpointSamples/Modifying the Standard Workflow of Vision/CreateWastageTransferLinesAutomatically.vb
+++ b/BreakpointSamples/Modifying the Standard Workflow of Vision/CreateWastageTransferLinesAutomatically.vb
@@ -12,7 +12,7 @@ Public Class CreateWastageTransferLines
 		Dim productDictionary as New Dictionary(Of String, Decimal)
 		
 		transaction.Lines.ToList().ForEach(Sub(ln) 
-							If ln.Notes = "Automatically calculated wastage" Then
+							If ln.Notes.Equals("Automatically calculated wastage") Then
 								transaction.Lines.Remove(ln)
 							End If
 						End Sub)													

--- a/BreakpointSamples/Modifying the Standard Workflow of Vision/DisableHeaderTaxCodeFieldOnTransactions.vb
+++ b/BreakpointSamples/Modifying the Standard Workflow of Vision/DisableHeaderTaxCodeFieldOnTransactions.vb
@@ -6,7 +6,7 @@
 
     Public Sub Invoke(transaction As Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoice, e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCellRepositoryEventArgs(Of Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoiceLine))
         'Check for the tax code field
-        If e.FieldName.Equals("TaxCode") Then
+        If e.FieldName.Equals("TaxCode") = True Then
             'Set to true to disable the tax code field
             e.Handled = True
         End If

--- a/BreakpointSamples/Modifying the Standard Workflow of Vision/DisableHeaderTaxCodeFieldOnTransactions.vb
+++ b/BreakpointSamples/Modifying the Standard Workflow of Vision/DisableHeaderTaxCodeFieldOnTransactions.vb
@@ -6,7 +6,7 @@
 
     Public Sub Invoke(transaction As Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoice, e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCellRepositoryEventArgs(Of Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoiceLine))
         'Check for the tax code field
-        If e.FieldName = "TaxCode" Then
+        If e.FieldName.Equals("TaxCode") Then
             'Set to true to disable the tax code field
             e.Handled = True
         End If

--- a/BreakpointSamples/Modifying the Standard Workflow of Vision/EnterQuantityUsingCustomRepository.vb
+++ b/BreakpointSamples/Modifying the Standard Workflow of Vision/EnterQuantityUsingCustomRepository.vb
@@ -6,7 +6,7 @@
 
     Public Sub Invoke(transaction As Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoice, e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCellRepositoryEventArgs(Of Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoiceLine))
         'Check for the quantity invoice field
-        If e.FieldName = "QuantityInvoice" Then
+        If e.FieldName.Equals("QuantityInvoice") = True Then
             'Set to true to enable the custom repository
             e.Handled = True
         End If

--- a/BreakpointSamples/Modifying the Standard Workflow of Vision/ForfeitSalesOrderDeposit.vb
+++ b/BreakpointSamples/Modifying the Standard Workflow of Vision/ForfeitSalesOrderDeposit.vb
@@ -16,7 +16,7 @@ Namespace Breakpoints.Debtors.SalesOrder 'Do not remove - SYBIZ
 		Public Sub Invoke(ByVal transaction As Sybiz.Vision.Platform.Debtors.Transaction.SalesOrder, ByVal e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCustomRibbonButtonClickEventArgs) 'Do not remove - SYBIZ
 			Try 'Do not remove - SYBIZ
 				'Enter your code below - SYBIZ
-				If e.Key = "ClearDeposit" Then 
+				If e.Key.Equals("ClearDeposit") = True Then 
 					If BreakpointHelpers.ShowYesNoMessageBox(e.Form, "WARNING", "Warning: This will cleanse this Sales Order and prepare an invoice for pay and process. Do you want to continue?") = DialogResult.Yes Then 
 						Dim soid = transaction.Id 
 						Dim depamount As Decimal 

--- a/BreakpointSamples/Modifying the Standard Workflow of Vision/OpenAddressInGoogleMapsWithCustomRibbonButton.vb
+++ b/BreakpointSamples/Modifying the Standard Workflow of Vision/OpenAddressInGoogleMapsWithCustomRibbonButton.vb
@@ -23,7 +23,7 @@
 
     Public Sub Invoke(transaction As Sybiz.Vision.Platform.Debtors.Transaction.SalesInvoice, e As Sybiz.Vision.Platform.Admin.Breakpoints.BreakpointCustomRibbonButtonClickEventArgs)
         'Check the key for the button that was clicked
-        If e.Key = "GoogleMaps" AndAlso transaction.Customer > 0 Then
+        If e.Key.Equals("GoogleMaps") = True AndAlso transaction.Customer > 0 Then
 
             'Get the default delivery address for the customer on the sales invoice
             Dim customer As Sybiz.Vision.Platform.Debtors.CustomerDetailInfo = Sybiz.Vision.Platform.Debtors.CustomerDetailInfo.GetObject(transaction.Customer)


### PR DESCRIPTION
Refactors all found string comparisons to use pattern of **[string].Equals("Test") = True**.

It is acknowledged that the "= True" is not required in any instance, but is included for clarity purposes.